### PR TITLE
Use separate JS variable to store file, Fixes drag + drop

### DIFF
--- a/datasette_upload_csvs/templates/upload_csv.html
+++ b/datasette_upload_csvs/templates/upload_csv.html
@@ -72,6 +72,10 @@ var progress = document.getElementsByTagName("progress")[0];
 var progressLabel = document.getElementById("progress-label");
 var label = dropArea.getElementsByTagName("label")[0];
 var tableName = document.getElementById("id_table_name");
+
+// State that holds the most-recent uploaded File, from a FileList
+let currentFile = null;
+
 progress.style.display = "none";
 fileInput.addEventListener("change", () => {
   setFile(fileInput.files[0]);
@@ -130,8 +134,8 @@ function formattedBytes(bytes) {
 }
 
 function setFile(file) {
-  if (fileInput.files[0] != file) {
-    fileInput.files[0] = file;
+  if (currentFile != file) {
+    currentFile = file;
   }
   label.innerText = file.name;
   label.innerHTML += '<br><span style="font-size: 0.9em">' + formattedBytes(file.size) + '</span>';
@@ -143,9 +147,12 @@ function setFile(file) {
 // Onsubmit handler
 uploadForm.addEventListener("submit", ev => {
   ev.preventDefault();
-  var file = fileInput.files[0];
-  if (!file || !tableName.value.trim()) {
-    alert("Please select a file and enter a table name");
+  if (!tableName.value.trim()) {
+    alert("Please enter a table name");
+    return;
+  }
+  if (!currentFile) {
+    alert("Please select a file");
     return;
   }
   var xhr = new XMLHttpRequest();
@@ -190,7 +197,7 @@ uploadForm.addEventListener("submit", ev => {
 
   formData.append("xhr", "1");
   formData.append("csrftoken", "{{ csrftoken() }}");
-  formData.append("csv", file);
+  formData.append("csv", currentFile);
   formData.append("table", tableName.value);
   xhr.send(formData);
 });


### PR DESCRIPTION
Click + upload works file, but drag + dropping a file does not. 

I believe it's because of this line:

https://github.com/simonw/datasette-upload-csvs/blob/0636bd08c76be59cbf22c6ac8fac4fe743ea7299/datasette_upload_csvs/templates/upload_csv.html#L134

The [`.files` property is immutable](https://developer.mozilla.org/en-US/docs/Web/API/FileList#:~:text=Note%3A%20This,items%20read%2Donly), so setting `.files[0] = something` doesn't work. For files that were uploaded manually, this worked fine because `inputFiles.files[0]` was set already. But when a file was dragged + dropped, setting `inputFiles.files[0]` to `e.dataTransfer.files[0]` wouldn't work.

So, I pulled `currentFile` as a separate JS variable and use that as the source-of-truth. 

https://github.com/simonw/datasette-upload-csvs/assets/15178711/570e8ade-9d3a-47be-b031-2892545d86a3


