### PR TITLE
migrate to `--internal` storage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -55,4 +55,3 @@ jobs:
       run: |
         python -m build
         twine upload dist/*
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,24 +7,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        datasette-version: ["<1.0", ">=1.0a7"]
+        exclude:
+        - python-version: "3.7"
+          datasette-version: ">=1.0a7"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
-      name: Configure pip caching
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        cache: pip
+        cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
         pip install -e '.[test]'
+        pip install "datasette${{ matrix.datasette-version }}"
     - name: Run tests
       run: |
         pytest
-

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     entry_points={"datasette": ["upload_csvs = datasette_upload_csvs"]},
     python_requires=">=3.7",
     install_requires=[
-        "datasette>=0.61",
+        "datasette>=1.0a5",
         "asgi-csrf>=0.7",
         "starlette",
         "aiofiles",


### PR DESCRIPTION
Datasette now has an private internal database plugins can use, so this PR moves the `_csv_progress_` table to that new database.

Gonna take a careful look at the tests for this one - I intermittently see `_csv_progress_ table is locked` errors, which I believe happens during `docs_with_progress()` . We probably should enable WAL on the internal database...