### PR TITLE
Add support for appending rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Datasette plugin for uploading CSV files and converting them to database tables
 
 ## Usage
 
-The plugin adds an interface at `/-/upload-csvs` for uploading a CSV file and using it to create a new database table.
+The plugin adds an interface at `/-/upload-csvs` for uploading a CSV file and using it to create a new database table. An interface provide an option to append rows to an existent table in the database.
 
 By default only [the root actor](https://datasette.readthedocs.io/en/stable/authentication.html#using-the-root-actor) can access the page - so you'll need to run Datasette with the `--root` option and click on the link shown in the terminal to sign in and access the page.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Datasette plugin for uploading CSV files and converting them to database tables
 
 ## Usage
 
-The plugin adds an interface at `/-/upload-csvs` for uploading a CSV file and using it to create a new database table. An interface provide an option to append rows to an existent table in the database.
+The plugin adds an interface at `/-/upload-csvs` for uploading a CSV file and using it to create a new database table. The interface provides an option to append rows to an existent table in the database.
 
 By default only [the root actor](https://datasette.readthedocs.io/en/stable/authentication.html#using-the-root-actor) can access the page - so you'll need to run Datasette with the `--root` option and click on the link shown in the terminal to sign in and access the page.
 

--- a/datasette_upload_csvs/__init__.py
+++ b/datasette_upload_csvs/__init__.py
@@ -120,12 +120,13 @@ async def upload_csvs(scope, receive, datasette, request):
         if table_name.endswith(".csv"):
             table_name = table_name[:-4]
 
-    # If the table already exists, add a suffix
-    suffix = 2
-    base_table_name = table_name
-    while await db.table_exists(table_name):
-        table_name = "{}_{}".format(base_table_name, suffix)
-        suffix += 1
+    if not formdata.get('append') == 'true':
+        # If the table already exists, add a suffix
+        suffix = 2
+        base_table_name = table_name
+        while await db.table_exists(table_name):
+            table_name = "{}_{}".format(base_table_name, suffix)
+            suffix += 1
 
     total_size = get_temporary_file_size(csv.file)
     task_id = str(uuid.uuid4())

--- a/datasette_upload_csvs/templates/upload_csv.html
+++ b/datasette_upload_csvs/templates/upload_csv.html
@@ -71,6 +71,10 @@ progress::-webkit-progress-value {
     <label for="id_table_name">Table name</label>&nbsp; &nbsp;
     <input required id="id_table_name" type="text" name="table_name">
 </p>
+<p style="margin-top: 1em">
+    <label for="id_table_append">Append rows <br/> (if the table exists)</label>&nbsp; &nbsp;
+    <input id="id_table_append" type="checkbox" name="table_append">
+</p>
 <p><input type="submit" value="Upload file" class="button"></p>
 </form>
 </div>
@@ -83,6 +87,7 @@ var progress = document.getElementsByTagName("progress")[0];
 var progressLabel = document.getElementById("progress-label");
 var label = dropArea.getElementsByTagName("label")[0];
 var tableName = document.getElementById("id_table_name");
+var tableAppend = document.getElementById("id_table_append");
 var databaseName = document.getElementById("id_database");
 
 // State that holds the most-recent uploaded File, from a FileList
@@ -211,6 +216,9 @@ uploadForm.addEventListener("submit", ev => {
   formData.append("csrftoken", "{{ csrftoken() }}");
   formData.append("csv", currentFile);
   formData.append("table", tableName.value);
+  if (tableAppend.checked) {
+    formData.append("append", tableAppend.checked);
+  }
   if (databaseName) {
     formData.append("database", databaseName.value);
   }


### PR DESCRIPTION
This PR adds the ability to append rows if a target table already exists. We use Datasette for a project related to extractive industries' transparency, and the ability to append rows enables us to incorporate the data ingestion workflow into the Datasette UI. Can you please take a look? 

---

Thanks a lot for your work on Datasette!